### PR TITLE
Add portfolio feature: table creation, role check, scan add/delete

### DIFF
--- a/Server/database/database_handler.py
+++ b/Server/database/database_handler.py
@@ -662,5 +662,3 @@ def delete_record(record_id: str):
     finally:
         cur.close()
         conn.close()  
-if __name__ == "__main__":
-    create_portfolio_tables()


### PR DESCRIPTION
Added three new tables: portfolios, portfolio_members, and portfolio_scans
Designed to support collaboration and structured tracking of scans related to a specific individual (e.g., a person being targeted or monitored)
Support for creating portfolios and assigning scans
Sharing portfolios with users (editor, viewer)
Role checking and secure scan retrieval per user

