### PR TITLE
Portfolio sharing only after request approval backend

### DIFF
--- a/Server/database/database_handler.py
+++ b/Server/database/database_handler.py
@@ -256,7 +256,7 @@ def has_access_to_portfolio(user_id: int, portfolio_id: int) -> bool:
         conn.close()
 
 # 2. Get all scans in the portfolio with encrypted data
-def get_encrypted_scans_from_portfolio(portfolio_id: int) -> list[tuple[int, str, str, int]]:
+def get_encrypted_scans_from_portfolio(portfolio_id: int) -> list[tuple[int, str, str, int, str]]:
     conn = get_db_connection()
     scans = []
     if not conn:
@@ -286,7 +286,7 @@ def get_scans_in_portfolio(user_id: int, portfolio_id: int) -> list[tuple[int, s
     decrypted_scans = []
     for scan_id, scan_time, encrypted_text, added_by_user_id, name in encrypted_scans:
         decrypted_text = decrypt_data(added_by_user_id, encrypted_text)
-        decrypted_scans.append((scan_id, scan_time, name))
+        decrypted_scans.append((scan_id, scan_time, name, decrypted_text))
 
     return decrypted_scans
 

--- a/Server/database/database_handler.py
+++ b/Server/database/database_handler.py
@@ -130,12 +130,27 @@ def create_portfolio_tables():
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                     );
                 """)
+
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS portfolio_join_requests (
+                        id SERIAL PRIMARY KEY,
+                        portfolio_id INTEGER REFERENCES portfolios(id) ON DELETE CASCADE,
+                        target_user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+                        requested_by_user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+                        role TEXT CHECK (role IN ('editor', 'viewer')) NOT NULL,
+                        status TEXT CHECK (status IN ('pending', 'approved', 'rejected')) DEFAULT 'pending',
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    );
+                """)
+
                 conn.commit()
                 logger.info("Portfolio-related tables created successfully.")
         except Exception as e:
             logger.error(f"Error creating portfolio tables: {e}")
         finally:
             conn.close()
+
+
 
 # Creates a new portfolio if user wants
 def add_portfolio(name: str, owner_id: int) -> Optional[int]:
@@ -184,33 +199,37 @@ def add_scan_to_portfolio(portfolio_id: int, scan_id: int, added_by_user_id: int
             conn.close()
     raise RuntimeError("Database connection failed.")
 
-# Adds another user to the portfolio with a role (editor/viewer).
+# Request to add another user to the portfolio with a role (editor/viewer). --Sends a join request instead of directly adding a member
 def share_portfolio_with_user(portfolio_id: int, requesting_user_id: int, target_user_id: int, role: str = 'editor') -> bool:
     user_role = get_user_role_in_portfolio(requesting_user_id, portfolio_id)
     if user_role not in ['owner', 'editor']:
         logger.warning(f"User {requesting_user_id} attempted to share portfolio {portfolio_id} without permission.")
-        raise PermissionError("Only owners or editors can share portfolios.")
+        raise PermissionError("Only owners or editors can invite users.")
+
+    # Check if already a member
+    current_role = get_user_role_in_portfolio(target_user_id, portfolio_id)
+    if current_role != 'notmember':
+        raise ValueError("User is already a member of this portfolio.")
+
+    # Check if a request is already pending
+    existing_status = get_request_status(portfolio_id, target_user_id)
+    if existing_status == "pending":
+        raise ValueError("A join request is already pending for this user.")
+    elif existing_status == "approved":
+        raise ValueError("User already has access (approved earlier).")
 
     conn = get_db_connection()
     if conn:
         try:
             with conn.cursor() as cur:
-                # Check if the user is already a member
-                cur.execute(
-                    "SELECT 1 FROM portfolio_members WHERE portfolio_id = %s AND user_id = %s;",
-                    (portfolio_id, target_user_id)
-                )
-                if cur.fetchone():
-                    raise ValueError("User is already a member of this portfolio.")
-
-                cur.execute(
-                    "INSERT INTO portfolio_members (portfolio_id, user_id, role) VALUES (%s, %s, %s);",
-                    (portfolio_id, target_user_id, role)
-                )
+                cur.execute("""
+                    INSERT INTO portfolio_join_requests (portfolio_id, target_user_id, requested_by_user_id, role)
+                    VALUES (%s, %s, %s, %s);
+                """, (portfolio_id, target_user_id, requesting_user_id, role))
                 conn.commit()
                 return True
         except Exception as e:
-            logger.error(f"Error sharing portfolio: {e}")
+            logger.error(f"Error creating join request: {e}")
             raise
         finally:
             conn.close()
@@ -277,7 +296,7 @@ def get_encrypted_scans_from_portfolio(portfolio_id: int) -> list[tuple[int, str
     return scans
 
 # Get decrypted scans only if access is valid
-def get_scans_in_portfolio(user_id: int, portfolio_id: int) -> list[tuple[int, str, str]]:
+def get_scans_in_portfolio(user_id: int, portfolio_id: int) -> list[tuple[int, str, str, str]]:
     if not has_access_to_portfolio(user_id, portfolio_id):
         logger.warning(f"User {user_id} has no access to portfolio {portfolio_id}")
         return []
@@ -860,3 +879,95 @@ def update_existing_scan_names():
             logger.error(f"Error updating scan names: {e}")
         finally:
             conn.close()
+
+#Get the request status of a portfolio share
+def get_request_status(portfolio_id: int, target_user_id: int) -> Optional[str]:
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT status FROM portfolio_join_requests
+                WHERE portfolio_id = %s AND target_user_id = %s
+                ORDER BY created_at DESC
+                LIMIT 1;
+            """, (portfolio_id, target_user_id))
+            row = cur.fetchone()
+            return row[0] if row else None
+    except Exception as e:
+        logger.error(f"Error getting request status for portfolio {portfolio_id}, user {target_user_id}: {e}")
+        return None
+    finally:
+        conn.close()
+
+#checks if a request is valid and pending. If so, user approves/rejects the request
+def respond_to_portfolio_request(user_id: int, request_id: int, action: str) -> bool:
+    """Defines the function with three parameters:
+      user_id: the ID of the user responding to the request (the target user)
+      request_id: the ID of the specific join request
+      action: either approve or reject
+    """
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        with conn.cursor() as cur:
+            # Get the request details
+            cur.execute("""
+                SELECT portfolio_id, target_user_id, role FROM portfolio_join_requests
+                WHERE id = %s AND target_user_id = %s AND status = 'pending';
+            """, (request_id, user_id))
+            row = cur.fetchone()
+            if not row:
+                return False
+
+            portfolio_id, target_user_id, role = row
+
+            if action == "approve":
+                cur.execute("""
+                    INSERT INTO portfolio_members (portfolio_id, user_id, role)
+                    VALUES (%s, %s, %s);
+                """, (portfolio_id, target_user_id, role))
+                cur.execute("""
+                    UPDATE portfolio_join_requests
+                    SET status = 'approved'
+                    WHERE id = %s;
+                """, (request_id,))
+            else:
+                cur.execute("""
+                    UPDATE portfolio_join_requests
+                    SET status = 'rejected'
+                    WHERE id = %s;
+                """, (request_id,))
+
+            conn.commit()
+            return True
+    finally:
+        conn.close()
+
+def get_pending_requests_for_user(user_id: int) -> list[tuple[int, int, str, str, str]]:
+    """
+    Returns all pending portfolio join requests for a specific user.
+
+    Returns:
+        A list of tuples with: (request_id, portfolio_id, portfolio_name, role, created_at)
+    """
+    conn = get_db_connection()
+    requests = []
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT r.id, r.portfolio_id, p.name, r.role, r.created_at
+                    FROM portfolio_join_requests r
+                    JOIN portfolios p ON r.portfolio_id = p.id
+                    WHERE r.target_user_id = %s AND r.status = 'pending'
+                    ORDER BY r.created_at DESC;
+                """, (user_id,))
+                requests = cur.fetchall()
+        except Exception as e:
+            logger.error(f"Error fetching pending requests for user {user_id}: {e}")
+        finally:
+            conn.close()
+    return requests

--- a/Server/server.py
+++ b/Server/server.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, FileResponse, JSONResponse
 from pydantic import BaseModel
 import cv2
+from typing import Literal
 
 from Data_recognition.data_type_recognition import classify_text
 from Enhance_Image.pictureChange import enhance_image
@@ -92,6 +93,10 @@ class RemoveMemberRequest(BaseModel):
 
 class ScanOwnershipRequest(BaseModel):
     scanId: int
+
+class RespondRequestBody(BaseModel):
+    requestId: int
+    action: Literal["approve", "reject"]
 
 def convert_to_formatted_string(detected_texts: list[tuple[str, str]]) -> str:
     # Join each tuple into a single line with label and value separated by ':'
@@ -597,6 +602,37 @@ async def check_scan_ownership(data: ScanOwnershipRequest, user: User = Depends(
     except Exception as e:
         logger.error(f"Error checking scan ownership: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+    
+@app.get("/portfolio/request/status")
+async def check_request_status(portfolio_id: int, user: User = Depends(get_current_user)):
+    try:
+        status = get_request_status(portfolio_id, user.id)
+        return {"status": status or "not_found"}
+    except Exception as e:
+        logger.error(f"Failed to fetch request status: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+    
+@app.get("/portfolio/request/pending")
+async def get_pending_requests(user: User = Depends(get_current_user)):
+    try:
+        requests = get_pending_requests_for_user(user.id)
+        return {"requests": requests}
+    except Exception as e:
+        logger.error(f"Failed to fetch pending requests: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.post("/portfolio/request/respond")
+async def respond_to_request(data: RespondRequestBody, user: User = Depends(get_current_user)):
+    try:
+        success = respond_to_portfolio_request(user.id, data.requestId, data.action)
+        if not success:
+            raise HTTPException(status_code=400, detail="Invalid request or already handled")
+        return {"message": f"Request {data.action}ed successfully"}
+    except Exception as e:
+        logger.error(f"Error responding to request: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
 
 @app.get("/{full_path:path}")
 async def serve_spa(full_path: str):


### PR DESCRIPTION
-fixed bug in a shared portfolio data decryption
-Added Approval Workflow for Sharing Portfolios
    Users can no longer be added to a portfolio immediately.
    Instead, a join request is inserted into a portfolio_join_requests table.
    The target user must explicitly approve the request.
----changes in fronted are needed ----
